### PR TITLE
Added initial functionality to scrap a list of blinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This script uses [ChromeDriver](chromedriver.chromium.org) to automate the Googl
 ```text
 usage: main.py [-h] [--language {de,en}] [--match-language]
                [--cooldown COOLDOWN] [--headless] [--audio] [--concat-audio]
-               [--no-scrape] [--book BOOK] [--category CATEGORY]
+               [--no-scrape] [--book BOOK] [--books BOOKS] [--category CATEGORY]
                [--create-html] [--create-epub] [--create-pdf]
                email password                                              
                                                                               
@@ -41,10 +41,10 @@ optional arguments:
   --book BOOK          Scrapes this book only, takes the blinkist url for the
                        book (e.g. https://www.blinkist.com/en/books/... or
                        nhttps://www.blinkist.com/en/nc/reader/...)
-  --books TEXT_FILE    Scrapes the list of books only, takes a txt file with the 
+  --books TEXT_FILE    Scrapes the list of books, takes a txt file with the 
                        list of blinkist urls for the books
                        (e.g. https://www.blinkist.com/en/books/... 
-                       or nhttps://www.blinkist.com/en/nc/reader/...)
+                       or https://www.blinkist.com/en/nc/reader/...)
   --book-category BOOK_CATEGORY
                         When scraping a single book, categorize it under this
                         category (works with '--book' only)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ optional arguments:
   --book BOOK          Scrapes this book only, takes the blinkist url for the
                        book (e.g. https://www.blinkist.com/en/books/... or
                        nhttps://www.blinkist.com/en/nc/reader/...)
+  --books TEXT_FILE    Scrapes the list of books only, takes a txt file with the 
+                       list of blinkist urls for the books
+                       (e.g. https://www.blinkist.com/en/books/... 
+                       or nhttps://www.blinkist.com/en/nc/reader/...)
   --book-category BOOK_CATEGORY
                         When scraping a single book, categorize it under this
                         category (works with '--book' only)

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ parser.add_argument('--audio', action='store_true', default=True, help='Download
 parser.add_argument('--concat-audio', action='store_true', default=False, help='Concatenate the audio blinks into a single file and tag it. Requires ffmpeg')
 parser.add_argument('--no-scrape', action='store_true', default=False, help='Don\'t scrape the website, only process existing json files in the dump folder')
 parser.add_argument('--book', default=False, help='Scrapes this book only, takes the blinkist url for the book (e.g. https://www.blinkist.com/en/books/... or nhttps://www.blinkist.com/en/nc/reader/...)')
+parser.add_argument('--books', default=False, help='Scrapes the list of books only, takes a txt file with the list of blinkist urls for the books (e.g. https://www.blinkist.com/en/books/... or nhttps://www.blinkist.com/en/nc/reader/...)')
 parser.add_argument('--book-category', default="Uncategorized", help='When scraping a single book, categorize it under this category (works with \'--book\' only)')
 parser.add_argument('--categories', type=str, nargs='+', default='', help=('Only the categories whose label contains at least one string here will be scraped. '
                                                                            'Case-insensitive; use spaces to separate categories. '
@@ -79,6 +80,12 @@ if __name__ == '__main__':
       if (is_logged_in):
         if (args.book):
           scrape_book(driver, processed_books, args.book, category={ "label" : args.book_category}, match_language=match_language)
+        elif (args.books):
+          with open(args.books, 'r') as books_urls:
+            for book_url in books_urls.readlines():
+              dump_exists = scrape_book(driver, processed_books, book_url.split('\n')[0], category={ "label" : args.book_category}, match_language=match_language)
+              if not dump_exists:           
+                time.sleep(args.cooldown)
         else:
           categories = scraper.get_categories(driver, args.language, args.categories, args.ignore_categories)
           for category in categories:

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ parser.add_argument('--audio', action='store_true', default=True, help='Download
 parser.add_argument('--concat-audio', action='store_true', default=False, help='Concatenate the audio blinks into a single file and tag it. Requires ffmpeg')
 parser.add_argument('--no-scrape', action='store_true', default=False, help='Don\'t scrape the website, only process existing json files in the dump folder')
 parser.add_argument('--book', default=False, help='Scrapes this book only, takes the blinkist url for the book (e.g. https://www.blinkist.com/en/books/... or nhttps://www.blinkist.com/en/nc/reader/...)')
-parser.add_argument('--books', default=False, help='Scrapes the list of books only, takes a txt file with the list of blinkist urls for the books (e.g. https://www.blinkist.com/en/books/... or nhttps://www.blinkist.com/en/nc/reader/...)')
+parser.add_argument('--books', default=False, help='Scrapes the list of books, takes a txt file with the list of blinkist urls for the books (e.g. https://www.blinkist.com/en/books/... or https://www.blinkist.com/en/nc/reader/...)')
 parser.add_argument('--book-category', default="Uncategorized", help='When scraping a single book, categorize it under this category (works with \'--book\' only)')
 parser.add_argument('--categories', type=str, nargs='+', default='', help=('Only the categories whose label contains at least one string here will be scraped. '
                                                                            'Case-insensitive; use spaces to separate categories. '


### PR DESCRIPTION
Some books, for some weird reason are not categorized in the Blinkist catalog. Hence, one need to manually scrap those books. This will help them scrapping all of them.