### PR TITLE
Cover image, concat, and metadata improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ optional arguments:
   --audio               Download the audio blinks for each book
   --concat-audio        Concatenate the audio blinks into a single file and
                         tag it. Requires ffmpeg
+  --embed-cover-art     Embed the Blink cover artwork into the concatenated
+                        audio file (works with '--concat-audio' only)
   --keep-noncat         Keep the individual blink audio files, instead of
-                        deleting them (works with '--concat-audio' only
+                        deleting them (works with '--concat-audio' only)
   --no-scrape           Don't scrape the website, only process existing json
                         files in the dump folder
   --book BOOK           Scrapes this book only, takes the blinkist url for the
@@ -72,6 +74,8 @@ optional arguments:
   --create-epub         Generate a formatted epub document for the book
   --create-pdf          Generate a formatted pdf document for the book.
                         Requires wkhtmltopdf
+  --save-cover          Save a copy of the Blink cover artwork in the folder.
+                        This image is used, also, by the generated HTML file.
   --chromedriver CHROMEDRIVER
                         Path to a specific chromedriver executable instead of
                         the built-in one

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -27,6 +27,7 @@ def scraped_audio_exists(book_json):
     if ((len(existing_audio_files) == chapter_count)): 
       # all audio blinks for the book have already been downloaded
       log.debug(f"Audio for all {chapter_count} blinks already exists")
+      return existing_audio_files;
     else:
       if (len(existing_audio_files) > 0): 
         log.debug(f"Found audio files for {len(existing_audio_files)} out of {chapter_count} blinks")
@@ -142,16 +143,17 @@ def main():
     if (book_json):
       cover_img_file = False
       cover_tmp_file = False
-      if (args.embed_cover_art):
-        cover_tmp_file = scraper.download_book_cover_image(book_json, filename='_cover.jpg',  alt_file='cover.jpg')
-      if (args.save_cover):
-        cover_img_file = scraper.download_book_cover_image(book_json, filename='cover.jpg',  alt_file='_cover.jpg')
       if (args.audio):
-        if (not scraped_audio_exists(book_json)):
+        audio_files = scraped_audio_exists(book_json)
+        if (not audio_files):
           audio_files = scraper.scrape_book_audio(driver, book_json, args.language)
-          if (audio_files and args.concat_audio):
+        if (audio_files and args.concat_audio):
+          if (type(audio_files) == list):
+            if (args.embed_cover_art):
+              cover_tmp_file = scraper.download_book_cover_image(book_json, filename='_cover.jpg',  alt_file='cover.jpg')
             generator.combine_audio(book_json, audio_files, args.keep_noncat, cover_tmp_file)
       if (args.save_cover):
+        cover_img_file = scraper.download_book_cover_image(book_json, filename='cover.jpg',  alt_file='_cover.jpg')
         generate_book_outputs(book_json, cover_img='cover.jpg')
       else:
         generate_book_outputs(book_json)


### PR DESCRIPTION
New image download and audio metadata functions
---

Adds the functionality described in Issue #16:
"Feature Request: Embed cover art into concat audio file"

The 640*640px version of the book's cover image can now be downloaded and/or embedded into the audio file using the `--embed-cover-art` and `--save-cover` flags. Downloaded cover art is also used for the HTML file output.

The FFmpeg tagging code has also been updated to be more readable, and it has a new "genre" (Blinkist) and "album" (book-category) tag, as well.


Fixed concat logic
---

Fixes a bug that was causing the audio concatenation process to get skipped. This is relevant when running the "concat" command on a book that already has all of the chapter audio downloaded (but no concat file).

Also slightly rearranges the cover-image downloading process - "cover_img_file" and "cover_tmp_file" downloads happen a little bit later now. "cover_tmp_file" will be only downloaded as necessary.

I tested these changes for various circumstances, and the code seems to behave as it should now. Feel free, however, to test it out yourself.

Might be related to #10. (Was originally fixed in pull-request #15.) Included in this pull request because it seemed to be interfering with my development process.