### PR TITLE
Fix book creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ optional arguments:
   --keep-noncat         Keep the individual blink audio files, instead of
                         deleting them (works with '--concat-audio' only)
   --no-scrape           Don't scrape the website, only process existing json
-                        files in the dump folder
+                        files in the dump folder. Do not provide email or 
+                        password with this option.
   --book BOOK           Scrapes this book only, takes the blinkist url for the
                         book(e.g. https://www.blinkist.com/en/books/... or
                         https://www.blinkist.com/en/nc/reader/...)
@@ -102,7 +103,7 @@ The script download audio blinks as well. This is done by waiting for a request 
 Add the `--concat-audio` argument to the script to concatenate the individual audio blinks into a single file and tag it with the appropriate book title and author. Doing this will delete all individual blinks and replace them with one audio file (per book), only. To keep both the individual blink audio files, also, use the `--keep-noncat` argument together with the `--concat-audio` argument (i.e. `--concat-audio --keep-noncat`). This requires the [ffmpeg](https://www.ffmpeg.org/) tool to be installed and present in the PATH.
 
 ## Processing book dumps with no scraping
-During scraping, the script saves all book's metadata in json files inside the `dump` folder. Those can be used by the script to re-generate the .html, .epub and .pdf output files without having to scrape the website again. To do so, pass the `--no-scrape` argument to the script.
+During scraping, the script saves all book's metadata in json files inside the `dump` folder. Those can be used by the script to re-generate the .html, .epub and .pdf output files without having to scrape the website again. To do so, pass the `--no-scrape` argument to the script without providing an email or a password.
 
 # Quirks & known Bugs
 - Some people have had troubles when dealing with long generated book files (> 260 characters in Windows). Although this should be handled gracefully by the script, if you keep seeing "FileNotFoundError" when trying to create the .html / .m4a files, try and turn on long filenames support on your system: https://www.itprotoday.com/windows-10/enable-long-file-name-support-windows-10, and make sure you have a recent distribution of ffmpeg if using it (old versions had some bugs in dealing with long filenames)

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -38,8 +38,7 @@ def scraped_audio_exists(book_json):
 
 def main():
   parser = argparse.ArgumentParser(description="Scrape blinkist.com and generate pretty output")
-  parser.add_argument("email", help="The email to log into your premium Blinkist account")
-  parser.add_argument("password", help="The password to log into your premium Blinkist account")
+
   parser.add_argument("--language", choices={"en", "de"}, default="en", 
                       help="The language to scrape books in - either 'en' for english or 'de' for german")
   parser.add_argument("--match-language", action="store_true", default=False, 
@@ -90,6 +89,10 @@ def main():
                       help="Embed the Blink cover artwork into the concatenated audio file (works with '--concat-audio' only)")
   parser.add_argument("--chromedriver", help='Path to a specific chromedriver executable instead of the built-in one')
   parser.add_argument("-v", "--verbose", action="store_true", help="Increases logging verbosity")
+
+  if '--no-scrape' not in sys.argv:
+    parser.add_argument("email", help="The email to log into your premium Blinkist account")
+    parser.add_argument("password", help="The password to log into your premium Blinkist account")
 
   args = parser.parse_args()
 

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -60,7 +60,7 @@ def main():
   parser.add_argument("--keep-noncat", action="store_true", default=False,
                       help="Keep the individual blink audio files, instead of deleting them (works with '--concat-audio' only")
   parser.add_argument("--no-scrape", action="store_true", default=False, 
-                      help="Don't scrape the website, only process existing json files in the dump folder")
+                      help="Don't scrape the website, only process existing json files in the dump folder. Do not provide email or password with this option.")
   parser.add_argument("--book", default=False, 
                       help="Scrapes this book only, takes the blinkist url for the book"
                       "(e.g. https://www.blinkist.com/en/books/... or https://www.blinkist.com/en/nc/reader/...)")

--- a/blinkistscraper/generator.py
+++ b/blinkistscraper/generator.py
@@ -37,7 +37,10 @@ def generate_book_html(book_json_or_file, cover_img_file=False):
     for chapter_json in book_json['chapters']:
       chapter_html = chapter_template
       for chapter_key in chapter_json:
-        chapter_html = chapter_html.replace(f'{{{chapter_key}}}', str(chapter_json[chapter_key]))
+        if chapter_json[chapter_key]:
+          chapter_html = chapter_html.replace(f'{{{chapter_key}}}', str(chapter_json[chapter_key]))
+        else:
+          chapter_html = chapter_html.replace(f'{{{chapter_key}}}', "")
       chapters_html.append(chapter_html)
 
   book_html = book_html.replace('{__chapters__}', "\n".join(chapters_html))
@@ -73,7 +76,11 @@ def generate_book_epub(book_json_or_file):
   # to-do: add who is this for / intro section with cover image
   for chapter_json in book_json['chapters']:
     chapter = epub.EpubHtml(title=chapter_json['title'], file_name=f"chapter_{chapter_json['order_no']}.xhtml", lang='hr')
-    chapter.content = f"<h2>{chapter_json['title']}</h2>" + chapter_json['content']
+
+    if chapter_json['supplement']:
+      chapter.content = f"<h2>{chapter_json['title']}</h2>" + chapter_json['text'] + chapter_json['supplement']
+    else:
+      chapter.content = f"<h2>{chapter_json['title']}</h2>" + chapter_json['text']
     book.add_item(chapter)
     chapters.append(chapter)
 

--- a/templates/chapter.html
+++ b/templates/chapter.html
@@ -1,2 +1,3 @@
 <h2>{title}</h2>
-{content}
+{text}
+{supplement}


### PR DESCRIPTION
## Fix book creation

I tested this with several books in both languages, with and without quotes.

### The issue

1. When blinkistscraper scrapes books, the audio files are correctly stored. However, the textual forms of the blinkists are missing content when the blinkist contains an interposed quote, such as in [this book](https://www.blinkist.com/en/books/kapital-und-ideologie-de).

     Instead of the chapter's content, only the quote is added to the book! 

2. I also removed the necessity to provide email and password with the `--no-scrape` option because that constitutes a useless effort and does not make sense at all.

**Notes and details**

The blink is correctly scraped (i.e. all content is retrieved) into the json, however it is incorrectly turned into html/epub/pdf.
In the json, three fields are of interest: `text`, `content` and `supplement`. The content field, which is used to create the books is actually redundant, because all information is contained in the other fields; in general, the text is stored twice in the json, however I don't address that in this PR.
In case there is a quote, `content` holds the quote, otherwise it contains the chapter text also found in the `text` field.
This is why the chapter text is sometimes lost. 
As in the blink, the quotes are displayed after the chapter in this PR.
While fixing the bug, I noticed that the epub does not contain the "About the author" section, whereas the html does. 
It might be worth considering using the html as the basis for the creation of both, the epub **and** the pdf.

_Note about the `--no-scrape` argument improvement:_
It turned out that argparse does not provide the functionality to have conditional arguments or optional positional arguments, which is why I chose a simple solution of not accepting the email and password arguments. 
This entails, that blinkistscraper can not be run if these are provided together with the  `--no-scrape` option, but considering the alternative of always having to provide email and password even when it does not make sense, I decided I would include the change in this PR, especially because anyone using the option will have read the readme or help text in order to know that this option exists and will be surprised he is forced to provide arguments which are not needed. In fact, at first try I didn't provide email and password because I didn't expect it to be necessary. It's of course your choice whether to follow this consideration.