### PR TITLE
fixed #40 and improvmented uncategorized books handling

### DIFF
--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -312,8 +312,7 @@ def main():
                         if not dump_exists:
                             time.sleep(args.cooldown)
             else:
-                # scrape all books / categories
-                all_books = scraper.get_all_books(driver, match_language)
+                # scrape all categories
                 categories = scraper.get_categories(
                     driver,
                     args.language,
@@ -334,6 +333,8 @@ def main():
                         # no scraping was involved, no need to cooldown
                         if not dump_exists:
                             time.sleep(args.cooldown)
+                # scrape all books to process uncategorized books
+                all_books = scraper.get_all_books(driver, match_language)
                 uncategorized_books = [x for x in all_books if x not in processed_books]
                 log.info(
                     f"Scraping {len(uncategorized_books)} remaining uncategorized books..."

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -313,7 +313,7 @@ def main():
                             time.sleep(args.cooldown)
             else:
                 # scrape all books / categories
-                all_books = scraper.get_all_books(driver, args.language)
+                all_books = scraper.get_all_books(driver, match_language)
                 categories = scraper.get_categories(
                     driver,
                     args.language,

--- a/blinkistscraper/scraper.py
+++ b/blinkistscraper/scraper.py
@@ -401,12 +401,8 @@ def scrape_book_audio(driver, book_json, language):
     # navigate to the book's reader page which also contains the media player for the first audio blink
     book_reader_url = f'https://www.blinkist.com/{language}/nc/reader/{book_json["slug"]}'
 
-    # check if the url needs to change
-    if not driver.current_url == book_reader_url:
-        log.info(f"Scraping book audio at {book_reader_url}")
-        driver.get(book_reader_url)
-    else:
-        log.info("Scraping book audio.")
+    log.info(f"Scraping book audio at {book_reader_url}")
+    driver.get(book_reader_url)
 
     # check for re-direct to the upgrade page
     detect_needs_upgrade(driver)

--- a/blinkistscraper/scraper.py
+++ b/blinkistscraper/scraper.py
@@ -256,13 +256,18 @@ def get_all_books_for_categories(driver, category):
     return books_links
 
 
-def get_all_books(driver, language):
+def get_all_books(driver, match_language):
     log.info(f"Getting all Blinkist books from sitemap...")
     all_books_links = []
     driver.get("https://www.blinkist.com/en/sitemap")
-    books_items = driver.find_elements_by_css_selector(
-        f".sitemap__section.sitemap__section--books a[href$='{language}']"
-    )
+    
+    if match_language:
+        selector = f".sitemap__section.sitemap__section--books a[href$='{match_language}']"
+    else:
+        selector = ".sitemap__section.sitemap__section--books a"
+
+    books_items = driver.find_elements_by_css_selector(selector)
+    
     for item in books_items:
         href = item.get_attribute("href")
         all_books_links.append(href)


### PR DESCRIPTION
Fixed #40 by always making a request to the book URL to ensure we get the necessary request header for the audio endpoint. I don't know how one can get the header at this point if we are already on the book URL without making the request or if this is even possible.

I think _get_all_books_ for uncategorized books should be done at the end in case the process ends prematurely. Occasionally I ran into a captcha after scraping the sitemap. By moving _get_all_books_ to the end this should get avoided for each incomplete run.
Also I consider the --match-language flag to get all books if desired.
