### PR TITLE
Collect Amazon product IDs and safe in *.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The script will automatically try to download and use the appropriate chromedriv
 usage: blinkistscraper [-h] [--language {en,de}] [--match-language]
                        [--cooldown COOLDOWN] [--headless] [--audio]
                        [--concat-audio] [--keep-noncat] [--no-scrape]
-                       [--book BOOK] [--daily-book] [--books BOOKS]
-                       [--book-category BOOK_CATEGORY]
+                       [--get-amazon-url] [--book BOOK] [--daily-book]
+                       [--books BOOKS] [--book-category BOOK_CATEGORY]
                        [--categories CATEGORIES [CATEGORIES ...]]
                        [--ignore-categories IGNORE_CATEGORIES [IGNORE_CATEGORIES ...]]
                        [--create-html] [--create-epub] [--create-pdf]
@@ -49,6 +49,8 @@ optional arguments:
   --no-scrape           Don't scrape the website, only process existing json
                         files in the dump folder. Do not provide email or
                         password with this option.
+  --get-amazon-url      Scrape Amazon product ID as well. Will additionally
+                        scrape https://.../en/books/ for this
   --book BOOK           Scrapes this book only, takes the blinkist url for the
                         book(e.g. https://www.blinkist.com/en/books/... or
                         https://www.blinkist.com/en/nc/reader/...)

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -104,7 +104,7 @@ def main():
         "--get-amazon-url",
         action="store_true",
         default=False,
-        help="Get Amazon book link as well. Will additionally scrape .../en/books/... for this",
+        help="Scrape Amazon product ID as well. Will additionally scrape https://.../en/books/ for this",
     )
     parser.add_argument(
         "--book",

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -101,6 +101,12 @@ def main():
         help="Don't scrape the website, only process existing json files in the dump folder. Do not provide email or password with this option.",
     )
     parser.add_argument(
+        "--get-amazon-url",
+        action="store_true",
+        default=False,
+        help="Get Amazon book link as well. Will additionally scrape .../en/books/... for this",
+    )
+    parser.add_argument(
         "--book",
         default=False,
         help="Scrapes this book only, takes the blinkist url for the book"
@@ -212,7 +218,7 @@ def main():
 
     def scrape_book(driver, processed_books, book_url, category, match_language):
         book_json, dump_exists = scraper.scrape_book_data(
-            driver, book_url, category=category, match_language=match_language
+            driver, book_url, args.get_amazon_url, category=category, match_language=match_language
         )
         if book_json:
             cover_img_file = False
@@ -350,7 +356,7 @@ def main():
                         driver,
                         processed_books,
                         book_url,
-                        category={"label": "Uncategorized"},
+                        category={"label": "Uncategorized", "id": -1},
                         match_language=match_language,
                     )
                     if not dump_exists:

--- a/blinkistscraper/utils.py
+++ b/blinkistscraper/utils.py
@@ -13,13 +13,12 @@ def get_or_read_json(book_json_or_file):
 def sanitize_name(name):
     return re.sub(r'[\\/*?:"<>|.]', "", name).strip()
 
+
 def sanitize_amazon_id(amazon_url):
     amazon_url = amazon_url.replace("https://www.amazon.de/dp/", "")
     amazon_url = amazon_url.replace("https://www.amazon.com/dp/", "")
     amazon_id = amazon_url.split('?tag=')[0].replace("/","")
     return amazon_id
-
-
 
 
 def get_book_dump_filename(book_json_or_url):

--- a/blinkistscraper/utils.py
+++ b/blinkistscraper/utils.py
@@ -13,6 +13,14 @@ def get_or_read_json(book_json_or_file):
 def sanitize_name(name):
     return re.sub(r'[\\/*?:"<>|.]', "", name).strip()
 
+def sanitize_amazon_id(amazon_url):
+    amazon_url = amazon_url.replace("https://www.amazon.de/dp/", "")
+    amazon_url = amazon_url.replace("https://www.amazon.com/dp/", "")
+    amazon_id = amazon_url.split('?tag=')[0].replace("/","")
+    return amazon_id
+
+
+
 
 def get_book_dump_filename(book_json_or_url):
     if "blinkist.com" in book_json_or_url:


### PR DESCRIPTION
**Use case**
Scrape Amazon product IDs from each book in order to later scrape the Amazon product pages for the review information.

**Functionality**
I scraped the Amazon product IDs ("ASIN") from the "Buy" button on the https://www.blinkist.com/en/books/... pages.
The ASIN is required to generate the Amazon product links `https://www.amazon.com/dp/<ASIN>`
If available, the product IDs are stored in the *.json files.
This feature needs to be enabled through the commandline switch `--get-amazon-url`

Also I added a "category_id" to the *.json files, that represents the index of the scraped category.