### PR TITLE
Docker compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ usage: blinkistscraper [-h] [--language {en,de}] [--match-language]
                        [--categories CATEGORIES [CATEGORIES ...]]
                        [--ignore-categories IGNORE_CATEGORIES [IGNORE_CATEGORIES ...]]
                        [--create-html] [--create-epub] [--create-pdf]
-                       [--save-cover] [--embed-cover-art]
-                       [--chromedriver CHROMEDRIVER] [-v]
+                       [--save-cover] [--embed-cover-art] 
+                       [--chromedriver CHROMEDRIVER] [--no-ublock] [--no-sandbox] [-v]
                        email password
 
 positional arguments:
@@ -85,6 +85,8 @@ optional arguments:
                         the built-in one
   --no-ublock           Disable the uBlock Chrome extension. Might be needed
                         to solve captcha
+  --no-sandbox          When running as root (e.g. in Docker), Chrome requires
+                        the '--no-sandbox' argument       
   -v, --verbose         Increases logging verbosity
 ```
 

--- a/blinkistscraper/__main__.py
+++ b/blinkistscraper/__main__.py
@@ -186,6 +186,13 @@ def main():
         help="Disable the uBlock Chrome extension. Might be needed to solve captcha",
     )
     parser.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        default=False,
+        help="When running as root (e.g. in Docker), Chrome requires the '--no-sandbox' argument",
+    )
+
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Increases logging verbosity"
     )
 
@@ -284,6 +291,7 @@ def main():
         driver = scraper.initialize_driver(
             headless=start_headless,
             with_ublock=use_ublock,
+            no_sandbox=args.no_sandbox,
             chromedriver_path=args.chromedriver,
         )
 

--- a/blinkistscraper/scraper.py
+++ b/blinkistscraper/scraper.py
@@ -35,7 +35,7 @@ def store_login_cookies(driver):
     pickle.dump(driver.get_cookies(), open("cookies.pkl", "wb"))
 
 
-def initialize_driver(headless=True, with_ublock=False, chromedriver_path=None):
+def initialize_driver(headless=True, with_ublock=False, no_sandbox=False, chromedriver_path=None):
     if not chromedriver_path:
         try:
             chromedriver_path = chromedriver_autoinstaller.install()
@@ -56,6 +56,8 @@ def initialize_driver(headless=True, with_ublock=False, chromedriver_path=None):
     chrome_options.add_argument("--log-level=3")
     chrome_options.add_argument("--silent")
     chrome_options.add_argument("--disable-logging")
+    if no_sandbox:
+        chrome_options.add_argument("--no-sandbox")
     # allows selenium to accept cookies with a non-int64 'expiry' value
     chrome_options.add_experimental_option("w3c", False)
     # removes the 'DevTools listening' log message


### PR DESCRIPTION
Added command-line switch `--no-sandbox`, which calls chrome with the option `--no-sandbox`.
This is necessary to allow running the whole blinkist-scraper + chrome setup as root inside a docker container.